### PR TITLE
Add closure gradients

### DIFF
--- a/SM3.py
+++ b/SM3.py
@@ -36,6 +36,7 @@ class SM3(Optimizer):
         defaults = {'lr': lr, 'momentum': momentum, 'beta': beta, 'eps': eps}
         super(SM3, self).__init__(params, defaults)
 
+    @torch.no_grad()
     def step(self, closure=None):
         """Performs single optimization step.
 
@@ -54,7 +55,7 @@ class SM3(Optimizer):
             for p in group['params']:
                 if p is None:
                     continue
-                grad = p.grad.data
+                grad = p.grad.detach()
 
                 state = self.state[p]
                 shape = grad.shape
@@ -109,7 +110,7 @@ class SM3(Optimizer):
                         update.mul_(1. - momentum).add_(momentum, m)
                         state['momentum_buffer'] = update.detach()
 
-                p.data.sub_(group['lr'], update)
+                p.sub_(group['lr'], update)
                 state['step'] += 1
         return loss
 

--- a/SM3.py
+++ b/SM3.py
@@ -55,7 +55,7 @@ class SM3(Optimizer):
             for p in group['params']:
                 if p is None:
                     continue
-                grad = p.grad.detach()
+                grad = p.grad
 
                 state = self.state[p]
                 shape = grad.shape

--- a/SM3.py
+++ b/SM3.py
@@ -46,7 +46,8 @@ class SM3(Optimizer):
         """
         loss = None
         if closure is not None:
-            loss = closure()
+            with torch.enable_grad():
+                loss = closure()
 
         for group in self.param_groups:
             momentum = group['momentum']


### PR DESCRIPTION
I recently learned that some people call `backward` in `closure`. Because of this, `closure` must be computed with gradients. Removed `detach` as unnecessary.